### PR TITLE
Revert "refactor out header.js into dat-header"

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const yo = require('yo-yo');
+const button = require('dat-button');
+const css = require('yo-css');
+const encoding = require('dat-encoding');
+
+const style = {
+
+};
+
+module.exports = (props) => {
+  const keydown = (e) => {
+    if (e.keyCode === 13) {
+      const link = e.target.value;
+      try {
+        encoding.decode(link);
+      } catch (err) {
+        throw new Error('Invalid link');
+      }
+      e.target.value = '';
+      props.download(link);
+    }
+  };
+  return yo`
+    <header style=${css(style)} class="dat-header">
+      <div class="dat-header__title">All Dats</div>
+      <div class="dat-header__actions">
+        <div class="dat-button">
+          ${button({
+            text: 'Create new Dat',
+            click: props.create
+          })}
+        </div>
+        <div class="dat-import">
+          <div class="dat-import--icon">
+            <img src="./public/img/link.svg" />
+          </div>
+          <input type="text" placeholder="Import dat" onkeydown=${keydown} class="dat-import--input">
+        </div>
+      </div>
+    </header>
+  `;
+};

--- a/lib/render.js
+++ b/lib/render.js
@@ -4,7 +4,7 @@ const yo = require('yo-yo');
 const button = require('dat-button');
 const encoding = require('dat-encoding');
 const bytes = require('bytes');
-const header = require('dat-header');
+const header = require('./header');
 const css = require('yo-css');
 
 const style = {
@@ -19,8 +19,7 @@ module.exports = (props) => yo`
   <div>
     ${header({
       create: props.create,
-      download: props.download,
-      title: 'All Dats'
+      download: props.download
     })}
     <table style=${css(style.table)} class="dat-list">
       <thead style=${css(style.heading)} class="dat-list__header">

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "dat-button": "^2.2.0",
     "dat-design": "^1.1.4",
     "dat-encoding": "^2.0.1",
-    "dat-header": "^1.0.3",
     "electron-prebuilt": "1.1.3",
     "hyperdrive": "^6.5.1",
     "hyperdrive-archive-swarm": "^3.1.0",


### PR DESCRIPTION
As per an earlier discussion with @juliangruber:

I suggest to revert this (at least for now). Sharing a header module between dat-desktop and dat.land seems to complicate things, as the headers will most likely have a different layout and maybe even consist of different components.

As currently things are still moving a lot and we are in exploration mode, I suggest to stick to this workflow for styles, which makes it much easier for me to iterate quickly:

- Keep all styles that are reusable in dat-design. Use classes, keeping in mind that they should be reusable and component-oriented (I follow this flavor of the [BEM naming convention](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/), which is not pretty but helps to keep our CSS more robust and readable as long as we have it in one global file).
- Make use of those styles in dat-desktop and dat.land by attaching CSS classes to the markup. 
- In dat-desktop/dat.land, add or overwrite any styles that are relevant to the app only, and won't be reused elsewhere. 

